### PR TITLE
Improved mixin target for `WorldSettingsImport`

### DIFF
--- a/src/main/java/com/telepathicgrunt/blame/mixin/WorldSettingsImportMixin.java
+++ b/src/main/java/com/telepathicgrunt/blame/mixin/WorldSettingsImportMixin.java
@@ -1,21 +1,20 @@
 package com.telepathicgrunt.blame.mixin;
 
+import java.util.function.Supplier;
+
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.MutableRegistry;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.WorldSettingsImport;
+
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.telepathicgrunt.blame.main.WorldSettingsImportBlame;
-import net.minecraft.util.RegistryKey;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.util.registry.SimpleRegistry;
-import net.minecraft.util.registry.WorldSettingsImport;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-
-import java.util.Collection;
-import java.util.Iterator;
 
 /* @author - TelepathicGrunt
  *
@@ -25,32 +24,11 @@ import java.util.Iterator;
  * LGPLv3
  */
 @Mixin(WorldSettingsImport.class)
-public class WorldSettingsImportMixin<E> {
-
-	/**
-	 * Grabs the current file we are at to pass to next mixin in case file explodes.
-	 */
-	@Inject(method = "decodeElements(Lnet/minecraft/util/registry/SimpleRegistry;Lnet/minecraft/util/RegistryKey;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/DataResult;",
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/util/ResourceLocation;getPath()Ljava/lang/String;", ordinal = 1),
-			locals = LocalCapture.CAPTURE_FAILHARD)
-	private void getCurrentFile(SimpleRegistry<E> registry, RegistryKey<? extends Registry<E>> registryKey, Codec<E> codec,
-								CallbackInfoReturnable<DataResult<SimpleRegistry<E>>> cir, Collection<ResourceLocation> collection,
-								DataResult<SimpleRegistry<E>> dataresult, String parentPath, Iterator<ResourceLocation> resourceLocationIterator,
-								ResourceLocation resourceLocation)
+public class WorldSettingsImportMixin<E>
+{
+	@Inject(method = "readAndRegisterElement", at = @At(value = "RETURN"))
+	private void addBrokenFileDetails(RegistryKey<? extends Registry<E>> registryKey, MutableRegistry<E> mutableRegistry, Codec<E> mapCodec, ResourceLocation id, CallbackInfoReturnable<DataResult<Supplier<E>>> cir)
 	{
-		WorldSettingsImportBlame.getCurrentFile(resourceLocation);
-	}
-
-	/**
-	 * Checks if the loaded datapack file errored and print it's resource location if it did
-	 */
-	@Inject(method = "decodeElements(Lnet/minecraft/util/registry/SimpleRegistry;Lnet/minecraft/util/RegistryKey;Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/DataResult;",
-			at = @At(value = "INVOKE_ASSIGN", target = "Lcom/mojang/serialization/DataResult;flatMap(Ljava/util/function/Function;)Lcom/mojang/serialization/DataResult;"),
-			locals = LocalCapture.CAPTURE_FAILHARD)
-	private void addBrokenFileDetails(SimpleRegistry<E> registry, RegistryKey<? extends Registry<E>> registryKey, Codec<E> codec,
-									  CallbackInfoReturnable<DataResult<SimpleRegistry<E>>> cir, Collection<ResourceLocation> collection,
-									  DataResult<SimpleRegistry<E>> dataresult)
-	{
-		WorldSettingsImportBlame.addBrokenFileDetails(dataresult);
+		WorldSettingsImportBlame.addBrokenFileDetails(registryKey, id, cir.getReturnValue());
 	}
 }


### PR DESCRIPTION
The issue: In the case of, for example, an erroring configured feature, a blame report was getting printed for every subsequent resource as well. This had several issues:

- It obscures the actual helpful error
- It falsely informs the user that there are errors with files that don't have any error at all.

I've moved the mixin to, what I believe, is a better location - catching the data result for the element *before* it's flat-mapped into the "result" `DataResult`, and adjusted the surrounding infrastructure to handle this new injection point. Notably, this location can be invoked for the same file (for instance, every time a configured feature is referenced by a biome), and so a "seen already" mechanism was added to avoid duplicating similar error messages.

@TelepathicGrunt I don't know what kind of code style or contribution mumbo jumbo you want here, so I tried to be as consistent with existing code - where there was consistency - as possible