### PR TITLE
Suppress unnecessary stacktraces for loot table and recipe errors. Also fix MC-190122

### DIFF
--- a/src/main/java/com/telepathicgrunt/blame/mixin/LootTableManagerMixin.java
+++ b/src/main/java/com/telepathicgrunt/blame/mixin/LootTableManagerMixin.java
@@ -1,16 +1,21 @@
 package com.telepathicgrunt.blame.mixin;
 
-import com.telepathicgrunt.blame.main.MissingLoottableBlame;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import org.apache.logging.log4j.Logger;
+import net.minecraft.client.resources.JsonReloadListener;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.LootTableManager;
 import net.minecraft.util.ResourceLocation;
+
+import com.telepathicgrunt.blame.main.MissingLoottableBlame;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.Map;
 
 /* @author - TelepathicGrunt
  *
@@ -19,7 +24,12 @@ import java.util.Map;
  * LGPLv3
  */
 @Mixin(LootTableManager.class)
-public class LootTableManagerMixin {
+public abstract class LootTableManagerMixin extends JsonReloadListener
+{
+	private LootTableManagerMixin(Gson gson_, String string_)
+	{
+		super(gson_, string_);
+	}
 
 	@Shadow
 	private Map<ResourceLocation, LootTable> tables;
@@ -31,5 +41,15 @@ public class LootTableManagerMixin {
 		if(!tables.containsKey(rl)){
 			MissingLoottableBlame.addMissingLoottableDetails(rl);
 		}
+	}
+
+	/**
+	 * Log a more useful message. Full stack trace is not useful. Concise, readable errors are useful.
+	 */
+	@SuppressWarnings("UnresolvedMixinReference")
+	@Redirect(method = "*(Lnet/minecraft/resources/IResourceManager;Lcom/google/common/collect/ImmutableMap$Builder;Lnet/minecraft/util/ResourceLocation;Lcom/google/gson/JsonElement;)V", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V"), require = 0, remap = false)
+	private void simplifyInvalidLootTableLogOutput(Logger logger, String message, Object p0, Object p1)
+	{
+		logger.error(message + " {}: {} (Blame: suppressed long stacktrace)", p0, p1.getClass().getSimpleName(), ((Exception) p1).getMessage());
 	}
 }

--- a/src/main/java/com/telepathicgrunt/blame/mixin/RecipeManagerMixin.java
+++ b/src/main/java/com/telepathicgrunt/blame/mixin/RecipeManagerMixin.java
@@ -1,0 +1,48 @@
+package com.telepathicgrunt.blame.mixin;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import org.apache.logging.log4j.Logger;
+import net.minecraft.client.resources.JsonReloadListener;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.util.ResourceLocation;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RecipeManager.class)
+public abstract class RecipeManagerMixin extends JsonReloadListener
+{
+	@Shadow private Map<IRecipeType<?>, Map<ResourceLocation, IRecipe<?>>> recipes;
+
+	private RecipeManagerMixin(Gson gson, String key)
+	{
+		super(gson, key);
+	}
+
+	/**
+	 * Log a more useful message. Full stack trace is not useful. Concise, readable errors are useful.
+	 * `require = 0` as this is the definition of non-essential
+	 */
+	@Redirect(method = "apply", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false), require = 0)
+	private void simplifyInvalidRecipeLogOutput(Logger logger, String message, Object p0, Object p1)
+	{
+		logger.error(message + " {}: {} (Blame: suppressed long stacktrace)", p0, p1.getClass().getSimpleName(), ((Exception) p1).getMessage());
+	}
+
+	/**
+	 * This fixes a stupid vanilla bug - when it logs "Loaded X recipes", it actually logs the number of recipe types, not the number of recipes. `require = 0` as this is the definition of non-essential
+	 * See MC-190122
+	 */
+	@Redirect(method = "apply", at = @At(value = "INVOKE", target = "Ljava/util/Map;size()I"), require = 0)
+	private int redirect$apply$size(Map<IRecipeType<?>, ImmutableMap.Builder<ResourceLocation, IRecipe<?>>> map)
+	{
+		return this.recipes.values().stream().mapToInt(Map::size).sum();
+	}
+}

--- a/src/main/resources/blame.mixins.json
+++ b/src/main/resources/blame.mixins.json
@@ -16,6 +16,7 @@
     "JigsawPatternMixin",
     "LootTableManagerMixin",
     "MinecraftServerAccessor",
+    "RecipeManagerMixin",
     "SingleJigsawPieceAccessor",
     "SingleJigsawPieceMixin",
     "StructureMixin",


### PR DESCRIPTION
This does three things:

- Redirect a logger call which is called during invalid recipes. Vanilla actually does a good job of discovering the error (because it's not using DFU!), but then buries it in a mile long stacktrace.
- Redirect a logger call which is called for invalid loot tables, for the exact same reason as above.
- Fix MC-190122 (Make the `Loaded X recipe(s)` message accurate.

With my test environment of TFC, this is an example of the log output with Blame:

```
[23:00:22] [Render thread/ERROR] [minecraft/RecipeManager]: Parsing error loading recipe tfc:collapse/andesite_cobble JsonSyntaxException: Invalid or unsupported recipe type 'tfc:collapse5' (Blame: suppressed long stacktrace)
[23:00:22] [Render thread/INFO] [minecraft/RecipeManager]: Loaded 2013 recipes
[23:00:22] [Render thread/ERROR] [minecraft/LootTableManager]: Couldn't parse loot table tfc:blocks/alabaster/raw/alabaster JsonSyntaxException: Expected name to be an item, was unknown string 'tfc:alabaster/raw/alabaster3' (Blame: suppressed long stacktrace)
```

And this was the same log output, without Blame. As you can see, it is extremely easy to bury actual informative log messages under useless junk.

```
[22:47:23] [Render thread/ERROR] [minecraft/RecipeManager]: Parsing error loading recipe tfc:collapse/andesite_cobble
com.google.gson.JsonSyntaxException: Invalid or unsupported recipe type 'tfc:collapse5'
	at net.minecraft.item.crafting.RecipeManager.lambda$fromJson$9(RecipeManager.java:178) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:classloading,pl:mixin:APP:tfc.mixins.json:item.crafting.RecipeManagerAccessor,pl:mixin:A}
	at java.util.Optional.orElseThrow(Optional.java:290) ~[?:1.8.0_202] {}
	at net.minecraft.item.crafting.RecipeManager.fromJson(RecipeManager.java:177) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:classloading,pl:mixin:APP:tfc.mixins.json:item.crafting.RecipeManagerAccessor,pl:mixin:A}
	at net.minecraft.item.crafting.RecipeManager.apply(RecipeManager.java:68) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:classloading,pl:mixin:APP:tfc.mixins.json:item.crafting.RecipeManagerAccessor,pl:mixin:A}
	at net.minecraft.item.crafting.RecipeManager.apply(RecipeManager.java:38) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:classloading,pl:mixin:APP:tfc.mixins.json:item.crafting.RecipeManagerAccessor,pl:mixin:A}
	at net.minecraft.client.resources.ReloadListener.lambda$reload$1(ReloadListener.java:17) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,re:mixin}
	at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656) ~[?:1.8.0_202] {}
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:632) ~[?:1.8.0_202] {}
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:442) ~[?:1.8.0_202] {}
	at net.minecraft.resources.AsyncReloader.lambda$null$3(AsyncReloader.java:82) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.doRunTask(ThreadTaskExecutor.java:195) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.concurrent.RecursiveEventLoop.doRunTask(RecursiveEventLoop.java:32) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:computing_frames,re:classloading}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.pollTask(ThreadTaskExecutor.java:158) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.managedBlock(ThreadTaskExecutor.java:172) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.client.Minecraft.makeServerStem(Minecraft.java:2183) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.loadWorld(Minecraft.java:2026) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.createLevel(Minecraft.java:1999) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.CreateWorldScreen.onCreate(CreateWorldScreen.java:359) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.CreateWorldScreen.lambda$init$11(CreateWorldScreen.java:291) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.widget.button.Button.onPress(Button.java:32) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.widget.button.AbstractButton.onClick(AbstractButton.java:24) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.widget.Widget.mouseClicked(Widget.java:192) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.INestedGuiEventHandler.mouseClicked(INestedGuiEventHandler.java:50) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:computing_frames,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.lambda$onPress$0(MouseHelper.java:111) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.Screen.wrapScreenError(Screen.java:595) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:computing_frames,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.onPress(MouseHelper.java:109) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.lambda$null$4(MouseHelper.java:213) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.execute(ThreadTaskExecutor.java:126) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.client.MouseHelper.lambda$setup$5(MouseHelper.java:212) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:36) ~[lwjgl-glfw-3.2.2.jar:build 10] {}
	at org.lwjgl.system.JNI.invokeV(Native Method) ~[lwjgl-3.2.2.jar:build 10] {}
	at org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3101) ~[lwjgl-glfw-3.2.2.jar:build 10] {}
	at com.mojang.blaze3d.systems.RenderSystem.flipFrame(RenderSystem.java:93) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MainWindow.updateDisplay(MainWindow.java:394) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.runTick(Minecraft.java:1232) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.run(Minecraft.java:778) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.main.Main.main(Main.java:185) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_202] {}
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_202] {}
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_202] {}
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_202] {}
	at net.minecraftforge.userdev.FMLUserdevClientLaunchProvider.lambda$launchService$0(FMLUserdevClientLaunchProvider.java:52) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:54) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:72) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:82) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:66) [modlauncher-8.0.9.jar:?] {}
	at net.minecraftforge.userdev.LaunchTesting.main(LaunchTesting.java:105) [forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {}
[22:47:23] [Render thread/INFO] [minecraft/RecipeManager]: Loaded 11 recipes
[22:47:23] [Render thread/ERROR] [minecraft/LootTableManager]: Couldn't parse loot table tfc:blocks/alabaster/raw/alabaster
com.google.gson.JsonSyntaxException: Expected name to be an item, was unknown string 'tfc:alabaster/raw/alabaster3'
	at net.minecraft.util.JSONUtils.lambda$convertToItem$0(JSONUtils.java:129) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at java.util.Optional.orElseThrow(Optional.java:290) ~[?:1.8.0_202] {}
	at net.minecraft.util.JSONUtils.convertToItem(JSONUtils.java:128) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.util.JSONUtils.getAsItem(JSONUtils.java:141) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.ItemLootEntry$Serializer.deserialize(ItemLootEntry.java:66) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.ItemLootEntry$Serializer.deserialize(ItemLootEntry.java:48) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.StandaloneLootEntry$Serializer.deserializeCustom(StandaloneLootEntry.java:195) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.StandaloneLootEntry$Serializer.deserializeCustom(StandaloneLootEntry.java:169) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootEntry$Serializer.deserialize(LootEntry.java:111) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootEntry$Serializer.deserialize(LootEntry.java:94) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootTypesManager$Serializer.deserialize(LootTypesManager.java:97) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.internal.bind.ArrayTypeAdapter.read(ArrayTypeAdapter.java:72) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:887) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:952) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.internal.bind.TreeTypeAdapter$GsonContextImpl.deserialize(TreeTypeAdapter.java:162) ~[gson-2.8.0.jar:?] {}
	at net.minecraft.util.JSONUtils.convertToObject(JSONUtils.java:371) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.util.JSONUtils.getAsObject(JSONUtils.java:382) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootPool$Serializer.deserialize(LootPool.java:225) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootPool$Serializer.deserialize(LootPool.java:222) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.internal.bind.ArrayTypeAdapter.read(ArrayTypeAdapter.java:72) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:887) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:952) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.internal.bind.TreeTypeAdapter$GsonContextImpl.deserialize(TreeTypeAdapter.java:162) ~[gson-2.8.0.jar:?] {}
	at net.minecraft.util.JSONUtils.convertToObject(JSONUtils.java:371) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.util.JSONUtils.getAsObject(JSONUtils.java:392) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootTable$Serializer.deserialize(LootTable.java:308) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootTable$Serializer.deserialize(LootTable.java:305) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:887) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:952) ~[gson-2.8.0.jar:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:925) ~[gson-2.8.0.jar:?] {}
	at net.minecraftforge.common.ForgeHooks.loadLootTable(ForgeHooks.java:880) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.loot.LootTableManager.lambda$apply$0(LootTableManager.java:50) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:classloading,pl:mixin:APP:blame.mixins.json:LootTableManagerMixin,pl:mixin:A}
	at java.util.HashMap.forEach(HashMap.java:1289) ~[?:1.8.0_202] {}
	at net.minecraft.loot.LootTableManager.apply(LootTableManager.java:48) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:classloading,pl:mixin:APP:blame.mixins.json:LootTableManagerMixin,pl:mixin:A}
	at net.minecraft.loot.LootTableManager.apply(LootTableManager.java:16) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:classloading,pl:mixin:APP:blame.mixins.json:LootTableManagerMixin,pl:mixin:A}
	at net.minecraft.client.resources.ReloadListener.lambda$reload$1(ReloadListener.java:17) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,re:mixin}
	at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656) ~[?:1.8.0_202] {}
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:632) ~[?:1.8.0_202] {}
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:442) ~[?:1.8.0_202] {}
	at net.minecraft.resources.AsyncReloader.lambda$null$3(AsyncReloader.java:82) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.doRunTask(ThreadTaskExecutor.java:195) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.concurrent.RecursiveEventLoop.doRunTask(RecursiveEventLoop.java:32) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,re:computing_frames,re:classloading}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.pollTask(ThreadTaskExecutor.java:158) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.managedBlock(ThreadTaskExecutor.java:172) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.client.Minecraft.makeServerStem(Minecraft.java:2183) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.loadWorld(Minecraft.java:2026) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.createLevel(Minecraft.java:1999) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.CreateWorldScreen.onCreate(CreateWorldScreen.java:359) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.CreateWorldScreen.lambda$init$11(CreateWorldScreen.java:291) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.widget.button.Button.onPress(Button.java:32) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.widget.button.AbstractButton.onClick(AbstractButton.java:24) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.widget.Widget.mouseClicked(Widget.java:192) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.INestedGuiEventHandler.mouseClicked(INestedGuiEventHandler.java:50) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:computing_frames,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.lambda$onPress$0(MouseHelper.java:111) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.Screen.wrapScreenError(Screen.java:595) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:computing_frames,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.onPress(MouseHelper.java:109) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.lambda$null$4(MouseHelper.java:213) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.execute(ThreadTaskExecutor.java:126) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.client.MouseHelper.lambda$setup$5(MouseHelper.java:212) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:36) ~[lwjgl-glfw-3.2.2.jar:build 10] {}
	at org.lwjgl.system.JNI.invokeV(Native Method) ~[lwjgl-3.2.2.jar:build 10] {}
	at org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3101) ~[lwjgl-glfw-3.2.2.jar:build 10] {}
	at com.mojang.blaze3d.systems.RenderSystem.flipFrame(RenderSystem.java:93) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MainWindow.updateDisplay(MainWindow.java:394) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.runTick(Minecraft.java:1232) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.run(Minecraft.java:778) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:tfc.mixins.json:client.MinecraftMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.main.Main.main(Main.java:185) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_202] {}
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_202] {}
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_202] {}
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_202] {}
	at net.minecraftforge.userdev.FMLUserdevClientLaunchProvider.lambda$launchService$0(FMLUserdevClientLaunchProvider.java:52) ~[forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:54) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:72) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:82) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:66) [modlauncher-8.0.9.jar:?] {}
	at net.minecraftforge.userdev.LaunchTesting.main(LaunchTesting.java:105) [forge-1.16.5-36.1.16_mapped_snapshot_complete-1.16.5-20210309-yarn-v2-recomp.jar:?] {}

```